### PR TITLE
#168383548 Implimented LFA feedback on db

### DIFF
--- a/app/controllers/userControllers.js
+++ b/app/controllers/userControllers.js
@@ -18,7 +18,8 @@ try{
     const createdUser = await user.signUpUser()
     const { id } = createdUser.rows[0]
     const token = jwt.sign({id, email, admin, mentor }, process.env.SECRETE_KEY, { expiresIn: '240hr' });
-    return res.status(201).send({ status: 201, message: 'User created successfully',token,user});
+    const { password, ...noA } = createdUser.rows[0];
+    return res.status(201).send({ status: 201, message: 'User created successfully',data:noA,token});
   } catch (error){
     return res.status(400).send({status:400, message:error.message});
   }
@@ -26,7 +27,8 @@ try{
 
 
   static signInUser(req, res) {
-    return res.send({ status: 200, message: 'User is successfully logged in', token: req.token })
+    const { password, ...noA } = req.user;
+    return res.send({ status: 200, message: 'User is successfully logged in',data:noA, token: req.token })
   }
 
   static changeUserToMentor(req, res) {

--- a/app/middlewares/auth.js
+++ b/app/middlewares/auth.js
@@ -38,7 +38,11 @@ class Auth {
   
     next();
   }
-
+  static rejectOnlyOwn(req, res, next) {
+    if (req.session.mentorid !== req.user.id) return res.status(403).send({ error: 403, message: 'You cannot reject a session for another mentor' });
+  
+    next();
+  }
   static async checkIfUserExist(req, res, next) {
     const { email } = req.body;
     const finduser = await User.getUserByEmail(email);
@@ -54,6 +58,7 @@ class Auth {
     if (!hashedpassword) return res.status(400).send({ message: 'wrong email or password' })
     const {id,admin,email,mentor} = user.rows[0]
     req.token = jwt.sign({id,admin,email,mentor}, process.env.SECRETE_KEY, { expiresIn: '240hr' });
+    req.user = user.rows[0]
     next();
   }
 

--- a/app/middlewares/session.js
+++ b/app/middlewares/session.js
@@ -1,6 +1,7 @@
 import { sessions}from '../data/sessionData';
 import Session from '../models/sessions';
 import { sessionReviews } from '../data/sessionReviews';
+import User from '../models/users';
 
 class Review{
   static async getSessionById(req,res,next){
@@ -10,11 +11,19 @@ class Review{
     
   next();
   }
-
-  static async questionExist(req,res,next){
+  static async sessionAlreadyExist(req,res,next){
     const{questions,mentorId}=req.body
-    const session = await Session.questionExist(questions,mentorId)
-      if(session.rows[0]) return res.status(409).send({error:409,message:'You cannot ask this mentor the same question'});
+    const session = await Session.sessionAlreadyExist(questions,mentorId)
+    if(session.rows[0]) return res.status(409).send({status:409, message:'session already exists'})
+    req.session = session.rows[0]
+    
+  next();
+  }
+  
+
+  static async ifMentorExists(req, res, next) {
+    const user = await User.getUserById(req.body.mentorId)
+    if (!user.rows[0]) return res.status(404).send({ status: 404, message: 'Mentor with the given Id not found' })
     next();
   }
 

--- a/app/models/sessions.js
+++ b/app/models/sessions.js
@@ -16,12 +16,14 @@ class Session {
         const values = [this.mentorId, this.questions, this.menteeId, this.menteeEmail]
         return client.query(sessionQuery, values); 
     }
-    
-    static questionExist(questions,mentorId){
-     const query = 'SELECT * FROM sessions WHERE questions=$1 and mentorId = $2 '
-        return client.query(query, [questions,mentorId]);   
-    }
+   
+    static sessionAlreadyExist(questions,mentorId){
+        const query = 'SELECT * FROM sessions WHERE questions=$1 and mentorId = $2 '
+           return client.query(query, [questions,mentorId]);   
+       }
 
+   
+   
     static acceptMentorshipSession(sessionId){ 
         const acceptSession = `UPDATE sessions SET status='accepted' WHERE sessionId= $1 RETURNING *`;
         return client.query(acceptSession, [sessionId]);

--- a/app/routers/apiRouters.js
+++ b/app/routers/apiRouters.js
@@ -11,9 +11,9 @@ router.post('/users/auth/signin', auth.checkIfUserNotExist, user.signInUser);
 router.patch('/user/:id',  auth.getToken, auth.verifyUserToken,auth.checkParamsInPut, auth.userAdmin, auth.getUserById, user.changeUserToMentor);
 router.get('/mentors', auth.getToken, user.getAllMentors);
 router.get('/mentor/:id', auth.getToken, auth.checkParamsInPut,auth.getUserById, user.specificMentor);
-router.post('/sessions',auth.getToken, auth.verifyUserToken,review.questionExist, session.createSession);
+router.post('/sessions',auth.getToken, auth.verifyUserToken,review.sessionAlreadyExist,review.ifMentorExists, session.createSession);
 router.patch('/sessions/:id/accept', auth.getToken, auth.verifyUserToken, auth.userMentor, review.getSessionById,auth.sessOwner, session.acceptMentorshipSession);
-router.patch('/sessions/:id/reject', auth.getToken, auth.verifyUserToken, auth.userMentor,review.getSessionById, session.rejectSession);
+router.patch('/sessions/:id/reject', auth.getToken, auth.verifyUserToken, auth.userMentor,review.getSessionById, auth.rejectOnlyOwn,session.rejectSession);
 router.post('/sessions/:id/review',auth.getToken, auth.verifyUserToken, review.getSessionById,review.notReviewYourSelf, review.notReviewAgain,review.shdReviewYourOwn, session.reviewSession )
 
 export default router;

--- a/test/auth.spec.js
+++ b/test/auth.spec.js
@@ -2,7 +2,10 @@ import express from 'express'
 import request from 'supertest';
 import should from 'should';
 import apiRouters from '../app/routers/apiRouters';
-import {authData} from './testData'
+import {
+    authData
+}
+from './testData'
 
 const app = express();
 
@@ -40,7 +43,7 @@ describe('auth routes', () => {
                 done();
             });
     });
-   
+
     it('signIn/login success', (done) => {
         request(app)
             .post('/api/v1/users/auth/signin')

--- a/test/mentor.spec.js
+++ b/test/mentor.spec.js
@@ -2,9 +2,18 @@ import express from 'express'
 import request from 'supertest';
 import should from 'should';
 import apiRouters from '../app/routers/apiRouters';
-import {authData} from './testData'
-import {mentorData} from './testData'
-import {sessionData} from './testData'
+import {
+    authData
+}
+from './testData'
+import {
+    mentorData
+}
+from './testData'
+import {
+    sessionData
+}
+from './testData'
 
 const app = express();
 
@@ -23,7 +32,7 @@ describe('Tests usermentor routes', () => {
                 done();
             });
     });
-   
+
     it('changeUserToMentor', (done) => {
         request(app)
             .patch('/api/v1/user/1')
@@ -86,7 +95,7 @@ describe('Tests usermentor routes', () => {
                 done();
             });
     });
-   
+
 });
 
 describe('Tests all usermentor routes', () => {
@@ -120,7 +129,7 @@ describe('Tests all usermentor routes', () => {
                 res.body.message.should.equal('for only admin');
                 done();
             });
-    }); 
+    });
 
     it('tests allMentors get token', (done) => {
         request(app)
@@ -132,7 +141,6 @@ describe('Tests all usermentor routes', () => {
             });
     });
 
-   
 });
 
 describe('Tests all specific mentor routes', () => {
@@ -176,13 +184,12 @@ describe('Tests all specific mentor routes', () => {
                 done();
             });
     });
-it('specficMentor not a mentor', (done) => {
+    it('specficMentor not a mentor', (done) => {
         request(app)
             .get('/api/v1/mentor/2')
             .set('Authorization', `Bearer ${userToken}`)
             .end((err, res) => {
-                
-                
+
                 done();
             });
     });

--- a/test/session.spec.js
+++ b/test/session.spec.js
@@ -2,9 +2,10 @@ import express from 'express'
 import request from 'supertest';
 import should from 'should';
 import apiRouters from '../app/routers/apiRouters';
-import {mentorData, authData,sessionData} from './testData'
-
-
+import {
+    mentorData, authData, sessionData
+}
+from './testData'
 
 const app = express();
 
@@ -31,7 +32,7 @@ describe('Tests session routes', () => {
             .send(sessionData[0])
             .end((err, res) => {
                 res.status.should.equal(200);
-                
+
                 done();
             });
     });
@@ -43,7 +44,7 @@ describe('Tests session routes', () => {
             .send(sessionData[5])
             .end((err, res) => {
                 res.status.should.equal(200);
-                
+
                 done();
             });
     });
@@ -55,11 +56,11 @@ describe('Tests session routes', () => {
             .send(sessionData[0])
             .end((err, res) => {
                 res.status.should.equal(409);
-                res.body.message.should.equal('You cannot ask this mentor the same question');
+                res.body.message.should.equal('session already exists');
                 done();
             });
     });
-  
+
     it('reject mentorship session for  only mentor', (done) => {
         request(app)
             .patch('/api/v1/sessions/1/reject')
@@ -89,7 +90,7 @@ describe('Tests mentoship  sessions routes', () => {
             .set('Authorization', `Bearer ${token}`)
             .end((err, res) => {
                 res.status.should.equal(200);
-                
+
                 done();
             });
     });
@@ -123,7 +124,6 @@ describe('Tests mentoship  sessions routes', () => {
             });
     });
 
-   
     it('reject mentorship session', (done) => {
         request(app)
             .patch('/api/v1/sessions/1/reject')
@@ -143,7 +143,6 @@ describe('Tests mentoship  sessions routes', () => {
             });
     });
 });
-
 
 describe('Tests Review session routes', () => {
     let token = '';


### PR DESCRIPTION
#### What does this PR do?
- Implement LFA feedback
#### Description of Task to be completed?
- Return the data of the user on signup and signin
- user should  not be able to request a session for a mentor who does not exist
- Format my responses correctly with status_code, message, and data
- question already answered should be session already exists
- I should not be able to reject a session that is not mine
#### How should this be manually tested?
- `clone` it
- run `npm run dev` in your terminal
-through postman
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/168383548
#### Screenshots (if appropriate)
![passwe](https://user-images.githubusercontent.com/50379737/64548319-3fb8de00-d2e3-11e9-9228-7a32456d7ff9.PNG)


[finishes#168345239]